### PR TITLE
Improve hero carousel controls

### DIFF
--- a/src/app/components/home/home.component.css
+++ b/src/app/components/home/home.component.css
@@ -99,6 +99,27 @@
   right: 10px;
 }
 
+.indicators {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+}
+
+.dot.active {
+  background-color: white;
+}
+
 
 @media (max-width: 768px) {
   .overlay {

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -16,6 +16,14 @@
         </div>
         <button class="prev" (click)="anterior()">&#10094;</button>
         <button class="next" (click)="siguiente()">&#10095;</button>
+        <div class="indicators">
+          <span
+            *ngFor="let imagen of imagenes; let i = index"
+            class="dot"
+            [class.active]="i === indiceActual"
+            (click)="goToSlide(i)"
+          ></span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -66,10 +66,17 @@ export class HomeComponent implements OnInit, OnDestroy{
 
   siguiente(): void {
     this.indiceActual = (this.indiceActual + 1) % this.imagenes.length;
+    this.resetAutoDesplazamiento();
   }
 
   anterior(): void {
     this.indiceActual = (this.indiceActual - 1 + this.imagenes.length) % this.imagenes.length;
+    this.resetAutoDesplazamiento();
+  }
+
+  goToSlide(indice: number): void {
+    this.indiceActual = indice;
+    this.resetAutoDesplazamiento();
   }
 
   iniciarAutoDesplazamiento(): void {
@@ -82,5 +89,10 @@ export class HomeComponent implements OnInit, OnDestroy{
     if (this.intervaloAutoDesplazamiento) {
       clearInterval(this.intervaloAutoDesplazamiento);
     }
+  }
+
+  private resetAutoDesplazamiento(): void {
+    this.detenerAutoDesplazamiento();
+    this.iniciarAutoDesplazamiento();
   }
 }


### PR DESCRIPTION
## Summary
- add slide indicators to hero carousel
- reset autoplay timer when manual navigation occurs

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbdbe648483278e01745a93b9b4a2