### PR TITLE
Improve plans carousel appearance

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -20,7 +20,7 @@ Este proyecto contiene varios componentes de Angular utilizados para construir l
 ## PlanesComponent
 
 - **Ubicación:** `src/app/components/planes/planes.component.ts`
-- **Descripción:** Muestra los planes de Internet disponibles mediante un carrusel de tarjetas con detalles de velocidad y precio. También genera un enlace dinámico a WhatsApp para solicitar cada plan.
+- **Descripción:** Muestra los planes de Internet en un carrusel automático con indicadores y flechas de navegación. Las tarjetas resaltan el plan recomendado y generan un enlace dinámico a WhatsApp para solicitar más información.
 
 ## BeneficiosComponent
 

--- a/src/app/components/home/home.component.css
+++ b/src/app/components/home/home.component.css
@@ -99,6 +99,27 @@
   right: 10px;
 }
 
+.indicators {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+}
+
+.dot.active {
+  background-color: white;
+}
+
 
 @media (max-width: 768px) {
   .overlay {

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -16,6 +16,14 @@
         </div>
         <button class="prev" (click)="anterior()">&#10094;</button>
         <button class="next" (click)="siguiente()">&#10095;</button>
+        <div class="indicators">
+          <span
+            *ngFor="let imagen of imagenes; let i = index"
+            class="dot"
+            [class.active]="i === indiceActual"
+            (click)="goToSlide(i)"
+          ></span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -66,10 +66,17 @@ export class HomeComponent implements OnInit, OnDestroy{
 
   siguiente(): void {
     this.indiceActual = (this.indiceActual + 1) % this.imagenes.length;
+    this.resetAutoDesplazamiento();
   }
 
   anterior(): void {
     this.indiceActual = (this.indiceActual - 1 + this.imagenes.length) % this.imagenes.length;
+    this.resetAutoDesplazamiento();
+  }
+
+  goToSlide(indice: number): void {
+    this.indiceActual = indice;
+    this.resetAutoDesplazamiento();
   }
 
   iniciarAutoDesplazamiento(): void {
@@ -82,5 +89,10 @@ export class HomeComponent implements OnInit, OnDestroy{
     if (this.intervaloAutoDesplazamiento) {
       clearInterval(this.intervaloAutoDesplazamiento);
     }
+  }
+
+  private resetAutoDesplazamiento(): void {
+    this.detenerAutoDesplazamiento();
+    this.iniciarAutoDesplazamiento();
   }
 }

--- a/src/app/components/planes/planes.component.css
+++ b/src/app/components/planes/planes.component.css
@@ -155,6 +155,47 @@ splide {
     color: var(--color-800);
   }
 
+/* Splide navigation styling */
+.splide__arrow {
+  background-color: var(--color-800);
+  color: var(--color-white);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  opacity: 0.8;
+}
+
+.splide__arrow:hover {
+  background-color: var(--color-red);
+}
+
+.splide__pagination {
+  bottom: -1.5rem;
+}
+
+.splide__pagination__page {
+  background-color: var(--color-100);
+  opacity: 1;
+}
+
+.splide__pagination__page.is-active {
+  background-color: var(--color-800);
+}
+
+.card-plan.recommended {
+  border-color: var(--color-red);
+  box-shadow: 0 0 10px rgba(215, 0, 0, 0.4);
+}
+
+.card-plan {
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.card-plan:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
   .icons-servicio {
     padding: 1rem;
     display: grid;

--- a/src/app/components/planes/planes.component.html
+++ b/src/app/components/planes/planes.component.html
@@ -6,7 +6,7 @@
         </div>
         <splide [options]="opciones">
             <splide-slide *ngFor="let imagen of imagenes">
-              <div class="card-plan">
+              <div class="card-plan" [class.recommended]="imagen.veneficio.instalacion">
                 <div class="card-head" *ngIf="imagen.veneficio.instalacion else sinInstalacion">
                     <span>{{imagen.veneficio.instalacion}}</span>
                 </div>

--- a/src/app/components/planes/planes.component.ts
+++ b/src/app/components/planes/planes.component.ts
@@ -16,15 +16,16 @@ import { MatIconModule } from '@angular/material/icon';
 })
 export class PlanesComponent {
   opciones = {
+    type: 'loop',
     perPage: 3,
     perMove: 1,
+    autoplay: true,
+    interval: 5000,
+    pauseOnHover: true,
+    gap: '1rem',
     breakpoints: {
-      1024: {
-        perPage: 2,
-      },
-      768: {
-        perPage: 1,
-      }
+      1024: { perPage: 2 },
+      768: { perPage: 1 }
     }
   };
 


### PR DESCRIPTION
## Summary
- autoplay plans carousel and add navigation styling
- highlight recommended plan card
- update components documentation

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbdbe648483278e01745a93b9b4a2